### PR TITLE
Add custom combo for LCTL_T(KC_A) + LT(2, KC_ENT) and migrate key override logic

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/config.h
@@ -77,6 +77,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BOTH_SHIFTS_TURNS_ON_CAPS_WORD
 
 //====================
+// Combos
+//====================
+
+// Per-combo timeout window
+#define COMBO_TERM_PER_COMBO
+// Controls if a given combo should fire only if tapped
+#define COMBO_MUST_TAP_PER_COMBO
+// Controls if a given combo should fire only if its keys are pressed in order
+#define COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
+
+//====================
 // VIA/VIAL
 //====================
 

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/features/combo.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/features/combo.c
@@ -1,0 +1,35 @@
+#include "quantum.h"
+#include "keymap.h"
+
+#ifdef COMBO_TERM_PER_COMBO
+uint16_t get_combo_term(uint16_t combo_index, const combo_t *combo) {
+  switch (combo_index) {
+    case A_ENT_TO_LCTL_SPC: // a_ent_to_lctl_spc
+      return 80; // Custom term for this combo
+    default:
+      return COMBO_TERM; // Default term for other combos
+  }
+}
+#endif
+
+#ifdef COMBO_MUST_TAP_PER_COMBO
+bool get_combo_must_tap(uint16_t combo_index, const combo_t *combo) {
+  switch (combo_index) {
+    case A_ENT_TO_LCTL_SPC: // a_ent_to_lctl_spc
+      return true; // Custom must tap for this combo
+    default:
+      return false; // Default must tap for other combos
+  }
+}
+#endif
+
+#ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
+bool get_combo_must_press_in_order(uint16_t combo_index, const combo_t *combo) {
+  switch (combo_index) {
+    case A_ENT_TO_LCTL_SPC: // a_ent_to_lctl_spc
+      return true; // Custom must press in order for this combo
+    default:
+      return false; // Default must press in order for other combos
+  }
+}
+#endif

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/features/process_record.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/features/process_record.c
@@ -2,13 +2,28 @@
 
 #include "keymap.h"
 
+bool is_key_tapped(keyrecord_t *record) {
+  return record->event.pressed && !record->tap.interrupted && record->tap.count > 0;
+}
+
+bool is_mod_held(uint16_t mod) {
+  return (get_mods() & MOD_BIT(mod)) != 0;
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
-    case MO(_MOUSE):
+    case MO(_MOUSE): // Mouse scroll mode
       if (record->event.pressed) {
         keyball_set_scroll_mode(true);
       } else {
         keyball_set_scroll_mode(false);
+      }
+      return true;
+    case LT(2, KC_ENT): // Modifier + Enter => Modifier + Space
+      // Don't use key overrides to act as the LT(2) key when held down
+      if (is_key_tapped(record) && (is_mod_held(KC_LCTL) || is_mod_held(KC_RALT))) {
+        tap_code(KC_SPACE);
+        return false; // Prevent default processing of this keycode
       }
       return true;
     default:

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.c
@@ -67,3 +67,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 };
 // clang-format on
+
+//====================
+// Combos
+//====================
+
+// Added this combo to prevent accidental "a+enter" input when intending "ctrl+enter" → maps "a+enter" to "ctrl+space"
+const uint16_t PROGMEM a_ent_to_lctl_spc[] = {LCTL_T(KC_A), LT(2, KC_ENT), COMBO_END};
+
+combo_t key_combos[] = {
+  [A_ENT_TO_LCTL_SPC] = COMBO(a_ent_to_lctl_spc, LCTL(KC_SPACE)),
+};

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.c
@@ -67,18 +67,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 };
 // clang-format on
-
-//====================
-// Key Overrides
-//====================
-
-// LCTRL + Enter => LCTRL + Space
-const key_override_t lctl_enter_to_space = ko_make_basic(MOD_BIT(KC_LCTL), LT(2, KC_ENT), LCTL(KC_SPACE));
-
-// RALT + Enter => RALT + Space
-const key_override_t ralt_enter_to_space = ko_make_basic(MOD_BIT(KC_RALT), LT(2, KC_ENT), RALT(KC_SPACE));
-
-const key_override_t *key_overrides[] = {
-    &lctl_enter_to_space,
-    &ralt_enter_to_space
-};

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/keymap.h
@@ -7,3 +7,7 @@ enum layer_names {
   _FUNCTIONS,
   _MOUSE,
 };
+
+enum combo_names {
+  A_ENT_TO_LCTL_SPC = 0,
+};

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/rules.mk
@@ -1,5 +1,6 @@
 # build rules
 SRC += \
+	features/combo.c \
 	features/hold_on_other_key_press.c \
 	features/layer_state.c \
 	features/oled.c \
@@ -12,6 +13,7 @@ SRC += \
 # Enable features
 VIA_ENABLE = yes
 CAPS_WORD_ENABLE = yes
+COMBO_ENABLE = yes
 
 # Disalbe lighting
 RGBLIGHT_ENABLE = no

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/drop-stones/rules.mk
@@ -11,7 +11,6 @@ SRC += \
 
 # Enable features
 VIA_ENABLE = yes
-KEY_OVERRIDE_ENABLE = yes
 CAPS_WORD_ENABLE = yes
 
 # Disalbe lighting


### PR DESCRIPTION
- Implements a combo mapping LCTL_T(KC_A) + LT(2, KC_ENT) to LCTL(KC_SPACE) to prevent accidental "a+enter" input.
- Moves modifier+Enter to Space logic from key overrides to combo and process_record_user.
- Adds per-combo configuration for timeout, must-tap, and must-press-in-order.
- Enables COMBO feature and disables KEY_OVERRIDE in rules.mk.
- Adds combo implementation in features/combo.c.